### PR TITLE
Change column to null

### DIFF
--- a/db/migrate/20210618215243_change_column_to_null_to_customer.rb
+++ b/db/migrate/20210618215243_change_column_to_null_to_customer.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToNullToCustomer < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :customers, :reset_password_token, true
+  end
+  
+  def down
+    change_column_null :customers, :reset_password_token, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_044441) do
+ActiveRecord::Schema.define(version: 2021_06_18_215243) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2021_06_17_044441) do
   create_table "customers", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "first_name", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,6 @@ Customer.create!(last_name: "茄子美",
                  postal_code: "1234567",
                  address: "東京都渋谷代々木神園町0-0",
                  telephone_number: "09011112222",
-                 reset_password_token: "50"
                  )
 
 49.times do |n|
@@ -40,7 +39,6 @@ Customer.create!(last_name: "茄子美",
                  postal_code: postal_code,
                  address: address.kanji,
                  telephone_number: telephone_number,
-                 reset_password_token: "#{n}"
                  )
 end
 


### PR DESCRIPTION
・reset_password_tokenのnull:falseを変更するマイグレーションファイルを作成。
・db/seeds.rb の reset_password_token が必要なくなったので削除。

確認よろしくお願いします。

＊マージ、ローカルにプル後、rails db:migrateではエラーが出る可能性があります。
(一度データベースからreset_password_token自体を消すことになるため、データベースにcustomerと紐づいたデータが存在している場合、受け付けてくれません。)
その場合、rails db:migrate:reset で対処可能です。(一度データベースに登録したデータをまっさらにするので、開発環境で各自作成したcustomerやgenre等は消えてしまいます。各自で追加で入れたデータについては、お手数ですがもう一度入れなおおしていただく必要があります。)
seeds.rbに記載のあるデータは、もう一度rails db:seed でデータベースに登録しなおすことができます。